### PR TITLE
Specify when to use the different string types

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,25 @@ problem. A known exception to this rule is in a Gems gemspec file.
   full_name = "#{first_name}, #{last_name}"
   ```
 
+* <a name="use-correct-string-type"></a>
+  Use single quotes as a default for string. Use double quotes when there is
+  interpolation and either double quotes OR single quotes. Use [percent notation](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Literals#The_.25_Notation)
+  when there is interpolation, single quotes, AND double quotes.
+
+  ```ruby
+  # bad
+  value1 = "test"
+  value2 = %(isn't this the best)
+  value3 = %(isn't this the #{description})
+  value4 = "\"She isn't my #{noun}\", he said."
+
+  # good
+  value1 = 'test'
+  value2 = "isn't is the best"
+  value3 = "isn't this the #{description}"
+  value4 = %("She isn't my #{noun}", he said.)
+  ```
+
 ## Naming
   * <a name="lower-snake-case"></a>
     Use lower case snake_case for methods.
@@ -619,4 +638,3 @@ Open tickets or send pull requests with improvements. Please write [good commit 
 Inspiration and some examples were taken from the following:
 
 [bbatsov's ruby style guide](https://github.com/bbatsov/ruby-style-guide)
-

--- a/README.md
+++ b/README.md
@@ -555,8 +555,9 @@ problem. A known exception to this rule is in a Gems gemspec file.
 
 * <a name="use-correct-string-type"></a>
   Use single quotes as a default for string. Use double quotes when there is
-  interpolation and either double quotes OR single quotes. Use [percent notation](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Literals#The_.25_Notation)
-  when there is interpolation, single quotes, AND double quotes.
+  interpolation and either double quotes OR single quotes, or there are
+  special characters that need to be escaped. Use [percent notation](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Literals#The_.25_Notation) when
+  there is interpolation, single quotes, AND double quotes.
 
   ```ruby
   # bad
@@ -564,12 +565,14 @@ problem. A known exception to this rule is in a Gems gemspec file.
   value2 = %(isn't this the best)
   value3 = %(isn't this the #{description})
   value4 = "\"She isn't my #{noun}\", he said."
+  value5 = 'hello\nworld'
 
   # good
   value1 = 'test'
   value2 = "isn't is the best"
   value3 = "isn't this the #{description}"
   value4 = %("She isn't my #{noun}", he said.)
+  value5 = "hello\nworld"
   ```
 
 ## Naming


### PR DESCRIPTION
We *should* be using single quotes for everything, unless we need to use
either a double-quote or percent notation. This defines rules to
follow which guide the decision for which string type to use.