### PR TITLE
Make double quotes the default string type

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,25 +558,27 @@ problem. A known exception to this rule is in a Gems gemspec file.
   ```
 
 * <a name="use-correct-string-type"></a>
-  Use single quotes as a default for string. Use double quotes when there is
-  interpolation and either double quotes OR single quotes, or there are
-  special characters that need to be escaped. Use [percent notation](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Literals#The_.25_Notation) when
-  there is interpolation, single quotes, AND double quotes.
+  Use double quotes as a default for strings. Use single quotes when there is
+  a specific need to not have interpolation or escaping capability. Use
+  [percent notation](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Literals#The_.25_Notation) when there is interpolation, single quotes, AND double
+  quotes.
 
   ```ruby
   # bad
-  value1 = "test"
+  value1 = 'test'
   value2 = %(isn't this the best)
   value3 = %(isn't this the #{description})
   value4 = "\"She isn't my #{noun}\", he said."
   value5 = 'hello\nworld'
+  value6 = "Use \\n to add a newline" # Ok-ish, but see alternative.
 
   # good
-  value1 = 'test'
+  value1 = "test"
   value2 = "isn't is the best"
   value3 = "isn't this the #{description}"
   value4 = %("She isn't my #{noun}", he said.)
   value5 = "hello\nworld"
+  value6 = 'Use \n to add a newline'
   ```
 
 ## Naming


### PR DESCRIPTION
There is an article found here:
http://viget.com/extend/just-use-double-quoted-ruby-strings
That raised some interesting points. The main reason for using single
quotes as a default, and only using double quotes when interpolation is
needed stems from the argument that double quotes require a higher
performance hit to process. This article seems to squash that theory,
along with a few others.