### PR TITLE
Fix ruby block syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ guide is meant to be able to change with it.
   # bad
   some_method(arg1,arg2,arg3) # No spaces after comma
 
-  some_method do {|a| puts a} # No spaces inside `{` and `}`
+  some_method {|a| puts a} # No spaces inside `{` and `}`
 
   # good
   some_method(arg1, arg2, arg3)
 
-  some_method do { |a| puts a }
+  some_method { |a| puts a }
   ```
 
 * <a name="no-spaces-inside-parenthesis"></a>


### PR DESCRIPTION
`some_method { |a| puts a }` is how you call a method with a block on one line, not `some_method do { |a| puts a }`

```
2.2.2 :006 > def method(&block); yield; end
 => :method
2.2.2 :007 > method { puts 'a' }
a
 => nil
2.2.2 :008 > method do { puts 'a' }
2.2.2 :009?>
```

cc @willrodriguez 